### PR TITLE
Fix to set new metadata object when editing Cell metadata

### DIFF
--- a/nblineage/nbextension/main.js
+++ b/nblineage/nbextension/main.js
@@ -20,7 +20,7 @@ define([
             callbacks.shell.reply = function (msg) {
                 if (msg.msg_type === 'execute_reply') {
                     console.log('[nblineage] execution end time', msg.header.date);
-                    $.extend(true, cell.metadata, {
+                    cell.metadata = $.extend(true, {}, cell.metadata, {
                         lc_cell_meme: {
                             execution_end_time: msg.header.date
                         }
@@ -38,7 +38,9 @@ define([
         codecell.CodeCell.prototype.clear_output = function () {
             var ret = previous_clear_output.apply(this, arguments);
             if (this.output_area.outputs.length === 0 && this.metadata['lc_cell_meme']){
-                delete this.metadata['lc_cell_meme']['execution_end_time'];
+                const new_cell_metadata = $.extend(true, {}, this.metadata);
+                delete new_cell_metadata['lc_cell_meme']['execution_end_time'];
+                this.metadata = new_cell_metadata
             }
             return ret;
         };

--- a/nblineage/tests/selenium/test_lc_cell_meme.py
+++ b/nblineage/tests/selenium/test_lc_cell_meme.py
@@ -283,6 +283,51 @@ def test_lc_cell_meme_copy_multiple_times(notebook):
         assert current_meme['branch_numbers'][:-1] == before_meme['branch_numbers']
 
 
+def test_lc_cell_meme_copy_multiple_times_from_same_cell_before_save(notebook):
+    notebook.edit_cell(index=0, content='print()')
+    copy_cells(notebook, 0)
+    for i in range(10):
+        paste_cells_below(notebook, base_index=i)
+    save_notebook(notebook)
+
+    metadata_list = get_cell_metadata_list(notebook)
+    current_meme_list = list(map(lambda x: x['lc_cell_meme']['current'], metadata_list))
+    for i in range(10):
+        assert_cell_meme_branch_number(current_meme_list[i + 1], 0)
+        before_meme = parse_cell_meme(current_meme_list[i])
+        current_meme = parse_cell_meme(current_meme_list[i + 1])
+        assert current_meme['uuid'] != before_meme['uuid']
+        assert metadata_list[i + 1]['lc_cell_meme']['previous'] == current_meme_list[i]
+        if i < 9:
+            next_meme = parse_cell_meme(current_meme_list[i + 2])
+            assert current_meme['uuid'] != next_meme['uuid']
+            assert metadata_list[i + 1]['lc_cell_meme']['next'] == current_meme_list[i + 2]
+
+
+def test_lc_cell_meme_copy_multiple_times_from_same_cell(notebook):
+    notebook.edit_cell(index=0, content='print()')
+    save_notebook(notebook)
+    copy_cells(notebook, 0)
+    for i in range(10):
+        paste_cells_below(notebook, base_index=i)
+        save_notebook(notebook)
+
+    metadata_list = get_cell_metadata_list(notebook)
+    current_meme_list = list(map(lambda x: x['lc_cell_meme']['current'], metadata_list))
+    for i in range(10):
+        assert_cell_meme_branch_number(current_meme_list[i + 1], 0)
+        before_meme = parse_cell_meme(current_meme_list[i])
+        current_meme = parse_cell_meme(current_meme_list[i + 1])
+        assert current_meme['uuid'] == before_meme['uuid']
+        assert before_meme['current'] != before_meme['current']
+        assert metadata_list[i + 1]['lc_cell_meme']['previous'] == current_meme_list[i]
+        if i < 9:
+            next_meme = parse_cell_meme(current_meme_list[i + 2])
+            assert current_meme['uuid'] == next_meme['uuid']
+            assert before_meme['current'] != next_meme['current']
+            assert metadata_list[i + 1]['lc_cell_meme']['next'] == current_meme_list[i + 2]
+
+
 def test_lc_cell_meme_copy_multiple_times_over_10(notebook):
     notebook.edit_cell(index=0, content='print()')
     save_notebook(notebook)

--- a/nblineage/tests/selenium/test_lc_cell_meme.py
+++ b/nblineage/tests/selenium/test_lc_cell_meme.py
@@ -315,16 +315,16 @@ def test_lc_cell_meme_copy_multiple_times_from_same_cell(notebook):
     metadata_list = get_cell_metadata_list(notebook)
     current_meme_list = list(map(lambda x: x['lc_cell_meme']['current'], metadata_list))
     for i in range(10):
-        assert_cell_meme_branch_number(current_meme_list[i + 1], 0)
+        assert_cell_meme_branch_number(current_meme_list[i + 1], 1)
         before_meme = parse_cell_meme(current_meme_list[i])
         current_meme = parse_cell_meme(current_meme_list[i + 1])
         assert current_meme['uuid'] == before_meme['uuid']
-        assert before_meme['current'] != before_meme['current']
+        assert current_meme['branch_numbers'] != before_meme['branch_numbers']
         assert metadata_list[i + 1]['lc_cell_meme']['previous'] == current_meme_list[i]
         if i < 9:
             next_meme = parse_cell_meme(current_meme_list[i + 2])
             assert current_meme['uuid'] == next_meme['uuid']
-            assert before_meme['current'] != next_meme['current']
+            assert before_meme['branch_numbers'] != next_meme['branch_numbers']
             assert metadata_list[i + 1]['lc_cell_meme']['next'] == current_meme_list[i + 2]
 
 


### PR DESCRIPTION
Fix #18 

Cellのmetadataを編集するときは、新しいmetadata objectを設定するように修正しました。

テストも追加しました。
テストファイル nblineage/tests/selenium/test_lc_cell_meme.py の編集にともない、改行コードをCRLFからLFに修正しました。diffを見る時はHide whitespace changesをONに設定すると見やすくなります。