### PR TITLE
Fix GitHub Actions workflow for branch patterns and UI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: main
   pull_request:
-    branches: '*'
+    branches: '**'
 
 jobs:
   build:
@@ -56,6 +56,13 @@ jobs:
 
         jupyter labextension list 2>&1 | grep -ie "nblineage.*OK"
         python -m jupyterlab.browser_check
+
+        jlpm install
+        cd ./ui-tests
+        jlpm install
+        jlpm playwright install
+        jlpm playwright test
+        cd ..
 
         pip install build
         python -m build --sdist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install node
       uses: actions/setup-node@v3
       with:
-       node-version: 16
+       node-version: 18
     - name: Install Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         architecture: 'x64'
 
     - name: Setup pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-3.9-${{ hashFiles('package.json') }}
@@ -35,7 +35,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
     - name: Setup yarn cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -70,7 +70,7 @@ jobs:
         pip uninstall -y myextension jupyterlab
         rm -rf myextension
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: myextension-sdist
         path: myextension.tar.gz
@@ -87,7 +87,7 @@ jobs:
       with:
         python-version: '3.9'
         architecture: 'x64'
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: myextension-sdist
     - name: Install and Test

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -30,14 +30,14 @@ jobs:
         run: |
           echo "::set-output name=dir::$(pip cache dir)"
       - name: Cache pip
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('package.json') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Cache checked links
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pytest-link-check
           key: ${{ runner.os }}-linkcheck-${{ hashFiles('**/.md') }}-md-links

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
 
     - name: Setup pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-3.9-${{ hashFiles('package.json') }}
@@ -34,7 +34,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
     - name: Setup yarn cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -72,12 +72,12 @@ jobs:
         npm pack
         mv nblineage-*.tgz myextension-nodejs.tgz
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: myextension-sdist
         path: myextension.tar.gz
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: myextension-nodejs
         path: myextension-nodejs.tgz
@@ -89,10 +89,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: myextension-sdist
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: myextension-nodejs
     - name: release


### PR DESCRIPTION
## Changes
- Change branch pattern from `'*'` to `'**'` in build workflow to match branches with slashes
- Update Node.js version from 16 to 18 (required by Playwright)
- Update deprecated GitHub Actions (cache, upload-artifact, download-artifact) from v2 to v4
- Add Playwright UI tests to build workflow for earlier error detection